### PR TITLE
Kk/login-signup-favoritesPage-fixes

### DIFF
--- a/app/api/auth_routes.py
+++ b/app/api/auth_routes.py
@@ -42,7 +42,7 @@ def login():
         user = User.query.filter(User.email == form.data['email']).first()
         login_user(user)
         return user.to_dict()
-    return {'errors': validation_errors_to_error_messages(form.errors)}, 401
+    return {'errors': validation_errors_to_error_messages(form.errors)}, 400
 
 
 @auth_routes.route('/logout')
@@ -73,7 +73,7 @@ def sign_up():
         db.session.commit()
         login_user(user)
         return user.to_dict()
-    return {'errors': validation_errors_to_error_messages(form.errors)}, 401
+    return {'errors': validation_errors_to_error_messages(form.errors)}, 400
 
 
 @auth_routes.route('/unauthorized')

--- a/app/forms/signup_form.py
+++ b/app/forms/signup_form.py
@@ -19,9 +19,15 @@ def username_exists(form, field):
     if user:
         raise ValidationError('Username is already in use.')
 
+def name_format(form, field):
+    # Checking to see if the input is in the requested format
+    name_pattern = r"^[a-zA-Z][a-zA-Z ]*$"
+    if not re.match(name_pattern, field.data):
+        raise ValidationError("Input can only contain letters and spaces in between words.")
+
 
 def email_format(form, field):
-    # Checking to see if the email inputted is in the reequested format
+    # Checking to see if the email inputted is in the requested format
     email = field.data
     email_pattern = r"^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
     if not re.match(email_pattern, email):
@@ -62,9 +68,9 @@ def starting_with_spaces(form, field):
 
 class SignUpForm(FlaskForm):
     first_name = StringField(
-        'first name', validators=[DataRequired(), starting_with_spaces, max_char_15])
+        'first name', validators=[DataRequired(), starting_with_spaces, max_char_15, name_format])
     last_name = StringField(
-        'last name', validators=[DataRequired(), starting_with_spaces, max_char_15])
+        'last name', validators=[DataRequired(), starting_with_spaces, max_char_15, name_format])
     username = StringField(
         'username', validators=[DataRequired(), username_exists, starting_with_spaces, max_char_40])
     email = StringField('email', validators=[DataRequired(), user_exists, starting_with_spaces, email_format, max_char_255])

--- a/react-app/src/components/Favorite-Components/FavoritesPage/index.js
+++ b/react-app/src/components/Favorite-Components/FavoritesPage/index.js
@@ -18,7 +18,7 @@ function FavoritesPage() {
   return (
     <>
       <div className="favoritespage-container">
-        <h1 className="favoritespage-header">Favorite items <span>{allFavorites.length} items</span></h1>
+        {allFavorites?.length ? <h1 className="favoritespage-header">Favorite items <span>{allFavorites.length} items</span></h1> : null}
         <div className="favoritetiles">
           {allFavorites ? (
             allFavorites.map((favorite) => {

--- a/react-app/src/components/Favorite-Components/FavoritesTile/index.js
+++ b/react-app/src/components/Favorite-Components/FavoritesTile/index.js
@@ -30,7 +30,7 @@ function FavoritesTile({ favorite }) {
             style={{ color: isFavorited ? "#A5192E" : "#000000" }}
           ></i>
         </div>
-          <Link to={`/products/${favorite.product_id}`}>
+          <Link to={`/products/${favorite.product_id}`} style={{textDecoration: "none"}}>
           <div className="fav-product-preview-img" title={favorite.name}>
             <img src={favorite.preview_image_url[0]} alt={favorite.name} />
           </div>

--- a/react-app/src/components/Favorite-Components/FavoritesTile/index.js
+++ b/react-app/src/components/Favorite-Components/FavoritesTile/index.js
@@ -13,12 +13,8 @@ function FavoritesTile({ favorite }) {
   }, [dispatch, isFavorited]);
 
   const toggleFavStatus = () => {
-    // setIsFavorited((prev) => !prev);
     setIsFavorited(false);
     dispatch(favoriteActions.removeFromCurrUserFavorites(favorite.product_id));
-    // console.log(isFavorited, "Is favorited state");
-    // if (isFavorited == false) {
-    // }
   };
 
   return (

--- a/react-app/src/components/LoginFormModal/LoginForm.css
+++ b/react-app/src/components/LoginFormModal/LoginForm.css
@@ -125,6 +125,7 @@
 }
 
 
+
 .error-input {
     background-color: #FDDCD8;
 }

--- a/react-app/src/components/LoginFormModal/index.js
+++ b/react-app/src/components/LoginFormModal/index.js
@@ -21,6 +21,7 @@ function LoginFormModal() {
   const toggleInputCN = (formField) =>
     showErrors && backendErrors[formField] ? "error-input" : "";
 
+
   //handles input change
   const handleInputChange = (e) => {
     const { name, value } = e.target;
@@ -85,7 +86,7 @@ function LoginFormModal() {
               required
             />
           </div>
-          {showErrors && <p className="errors-text">{backendErrors.email}</p>}
+          {backendErrors?.email && showErrors && <p className="errors-text">{backendErrors.email}</p>}
 
           <div className="password-div">
             <label>Password</label>
@@ -102,9 +103,7 @@ function LoginFormModal() {
               required
             />
           </div>
-          {showErrors && (
-            <p className="errors-text">{backendErrors.password}</p>
-          )}
+          {backendErrors?.password && showErrors && <p className="errors-text">{backendErrors.password}</p>}
 
           <div className="login-buttons-div">
             <button className="login-submit-button" type="submit">

--- a/react-app/src/components/SignupFormModal/index.js
+++ b/react-app/src/components/SignupFormModal/index.js
@@ -64,7 +64,7 @@ function SignupFormModal() {
 	useEffect(() => {
 		const errors = {};
 		const email_pattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
-		const name_pattern = /^[a-zA-Z][a-zA-Z ]*[a-zA-Z]$/;
+		const name_pattern = /^[a-zA-Z][a-zA-Z ]*$/;
 		if (!formValues.firstName) errors.firstName = "First name is required.";
 		if (!formValues.lastName) errors.lastName = "Last name is required.";
 		if (!formValues.email) errors.email = "Email is required.";
@@ -97,6 +97,8 @@ function SignupFormModal() {
 
 		setFormErrors(errors);
 	}, [formValues, backendErrors])
+
+	console.log('CURRENT BACKEND ERRORS:---', backendErrors)
 
 
 	return (

--- a/react-app/src/components/SignupFormModal/index.js
+++ b/react-app/src/components/SignupFormModal/index.js
@@ -24,7 +24,8 @@ function SignupFormModal() {
 	//handles input change
 	const handleInputChange = (e) => {
 		const {name, value} = e.target;
-		setFormValues({...formValues, [name]:value});
+		const trimmedValue = (name === "firstName" || name === "lastName") ? value.trimStart() : value.trim();
+		setFormValues({...formValues, [name]:trimmedValue});
 	};
 
 	//handles demo user log in
@@ -39,8 +40,13 @@ function SignupFormModal() {
 		setCanSubmit(true);
 		setShowErrors(true);
 		const {username, email, password, firstName, lastName} = formValues;
+		const trimmedFormValues = Object.fromEntries(
+			Object.entries(formValues).map(([key, value]) => [key, value.trim()])
+		  );
+		  setFormValues(trimmedFormValues);
 		const data = await dispatch(signUp(username, email, password, firstName, lastName));
-		dispatch(getCart())
+		dispatch(getCart());
+
 		if (data) {
 			const dataErrors = {};
 			data?.forEach(error => {
@@ -58,6 +64,7 @@ function SignupFormModal() {
 	useEffect(() => {
 		const errors = {};
 		const email_pattern = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+		const name_pattern = /^[a-zA-Z][a-zA-Z ]*[a-zA-Z]$/;
 		if (!formValues.firstName) errors.firstName = "First name is required.";
 		if (!formValues.lastName) errors.lastName = "Last name is required.";
 		if (!formValues.email) errors.email = "Email is required.";
@@ -80,6 +87,8 @@ function SignupFormModal() {
 		if (formValues.confirmPassword.length > 255) errors.confirmPassword = "Input must not exceed 255 characters.";
 		if (formValues.password.length < 6) errors.password = "Must be at least 6 characters.";
 
+		if (!name_pattern.test(formValues.firstName)) errors.firstName = "Input can only contain letters and spaces in between words.";
+		if (!name_pattern.test(formValues.lastName)) errors.lastName = "Input can only contain letters and spaces in between words.";
 		if (!email_pattern.test(formValues.email)) errors.email = "Not a valid email.";
 		if (formValues.password !== formValues.confirmPassword) errors.confirmPassword = "Confirm Password field must be the same as the Password field.";
 
@@ -95,6 +104,7 @@ function SignupFormModal() {
 		<div className="signup-container">
 			<h1>Create your account</h1>
 			<h2>Registration is easy.</h2>
+			<pre>{JSON.stringify(formValues, undefined, 2)}</pre>
 			<form className="signup-form" onSubmit={handleSubmit}>
 				<div className="firstname-div">
 					<label>First name<span style={{"color": "#B64B59"}}>*</span></label>
@@ -108,7 +118,7 @@ function SignupFormModal() {
 						required
 					/>
 				</div>
-				{showErrors && <p className="errors-text">{formErrors.firstName}</p>}
+				{formErrors?.firstName && showErrors && <p className="errors-text">{formErrors.firstName}</p>}
 
 
 				<div className="lastname-div">
@@ -123,7 +133,7 @@ function SignupFormModal() {
 						required
 					/>
 				</div>
-				{showErrors && <p className="errors-text">{formErrors.lastName}</p>}
+				{formErrors?.lastName && showErrors && <p className="errors-text">{formErrors.lastName}</p>}
 
 
 				<div className="email-div">
@@ -134,12 +144,12 @@ function SignupFormModal() {
 						title="Please fill out this field."
 						value={formValues.email}
 						onChange={handleInputChange}
-						onFocus={() => {if (backendErrors.hasOwnProperty("email")) delete backendErrors["email"]}}
+						onInput={() => {if (backendErrors.hasOwnProperty("email")) delete backendErrors["email"]}}
 						className={toggleInputCN("email")}
 						required
 					/>
 				</div>
-				{showErrors && <p className="errors-text">{formErrors.email}</p>}
+				{formErrors?.email && showErrors && <p className="errors-text">{formErrors.email}</p>}
 
 
 				<div className="username-div">
@@ -150,12 +160,12 @@ function SignupFormModal() {
 						title="Please fill out this field."
 						value={formValues.username}
 						onChange={handleInputChange}
-						onFocus={()=> {if (backendErrors.hasOwnProperty("username")) delete backendErrors["username"]}}
+						onInput={()=> {if (backendErrors.hasOwnProperty("username")) delete backendErrors["username"]}}
 						className={toggleInputCN("username")}
 						required
 					/>
 				</div>
-				{showErrors && <p className="errors-text">{formErrors.username}</p>}
+				{formErrors?.username && showErrors && <p className="errors-text">{formErrors.username}</p>}
 
 
 				<div className="password-div">
@@ -170,7 +180,7 @@ function SignupFormModal() {
 						required
 					/>
 				</div>
-				{showErrors && <p className="errors-text">{formErrors.password}</p>}
+				{formErrors?.password && showErrors && <p className="errors-text">{formErrors.password}</p>}
 
 
 				<div className="confirm-password-div">
@@ -185,7 +195,7 @@ function SignupFormModal() {
 						required
 					/>
 				</div>
-				{showErrors && <p className="errors-text">{formErrors.confirmPassword}</p>}
+				{formErrors?.confirmPassword && showErrors && <p className="errors-text">{formErrors.confirmPassword}</p>}
 
 
 				<div className="signup-button-divs">


### PR DESCRIPTION
Login and Signup modals:
- When a user successfully logs in or signups, the hidden error <p> elements no longer expand as if errors would fill the space.
- Added additional backend and frontend validation checks: firstName & lastName input now only allow letters and spaces between words.
- Added trimming to the start and end of user input for all fields, except for firstName & lastName fields which will allow white spaces at the end (in case a 2-part first name or last name is used) and any whitespace will be removed after the user submits the form.
- Went into api/auth_routes.py to change validation error status code to be 400 rather than 401.


FavoritesPage component:
- Modified "Favorite items" header to render under a condition.
- Added "textDecoration: none" to Link element styling because without it, each list item for a favorited item tile was underlined.